### PR TITLE
Fixing Capitalized function to return the input when the same is not a String.

### DIFF
--- a/microtext.js
+++ b/microtext.js
@@ -142,11 +142,16 @@ Microtext.abbrevName = function (expr) {
  */
 Microtext.capitalize = function (expr) {
     "use strict";
-    if (expr.constructor === String) {
-        expr = expr.charAt(0).toUpperCase() + expr.slice(1);
+    var capitalized;
+    if (expr !== undefined) {
+        if (expr.constructor === String) {
+            capitalized = expr.charAt(0).toUpperCase() + expr.slice(1);
+        } else {
+            capitalized = expr.toString();
+        }
     }
 
-    return expr;
+    return capitalized;
 };
 
 /**


### PR DESCRIPTION
Currently.

``` javascript
Microtext.capitalize(92830);
TypeError: Object 92830 has no method 'charAt'
```

Correct return:

``` javascript
Microtext.capitalize(92830);
92830
```
